### PR TITLE
Fix incorrect table name for rates

### DIFF
--- a/src/api/mercury/rate/route.ts
+++ b/src/api/mercury/rate/route.ts
@@ -38,7 +38,7 @@ export const POST = async (
         currency_rate = 1;
     } else {
         const {data: recentRates} = await query.graph({
-            entity: "mercury_rates",
+            entity: "mercury_rate",
             fields: ["*"],
             filters: {
                 from: from.toUpperCase(),
@@ -63,7 +63,7 @@ export const POST = async (
     }
 
     const {data: recentRates} = await query.graph({
-        entity: "mercury_rates",
+        entity: "mercury_rate",
         fields: ["*"],
         filters: {
             from: "USD",

--- a/src/jobs/check-ada-price.ts
+++ b/src/jobs/check-ada-price.ts
@@ -26,7 +26,7 @@ export default async function checkAdaPriceJob(container: MedusaContainer): Prom
     const freshAdaPrice = new Date(Date.now() - (updateAdaPricePeriod * 60 * 1000));
 
     const {data: recentRates} = await query.graph({
-        entity: "mercury_rates",
+        entity: "mercury_rate",
         fields: ["*"],
         filters: {
             from: "USD",
@@ -62,7 +62,7 @@ export default async function checkAdaPriceJob(container: MedusaContainer): Prom
         }
 
         const {data: recentRates} = await query.graph({
-            entity: "mercury_rates",
+            entity: "mercury_rate",
             fields: ["*"],
             filters: {
                 from: currency.currency_code.toUpperCase(),


### PR DESCRIPTION
## Summary
- fix job and route to query `mercury_rate` table instead of `mercury_rates`

## Testing
- `npm run build` *(fails: medusa not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406920dac8832eaecee58a3bbe8e55