### PR TITLE
fix: record payment metadata

### DIFF
--- a/src/api/store/mercury/authorize/route.ts
+++ b/src/api/store/mercury/authorize/route.ts
@@ -1,5 +1,5 @@
 import {MedusaRequest, MedusaResponse} from "@medusajs/framework/http";
-import {processPaymentWorkflow} from "@medusajs/medusa/core-flows"
+import {authorizePaymentSessionStep, processPaymentWorkflow} from "@medusajs/medusa/core-flows"
 import {ContainerRegistrationKeys} from "@medusajs/framework/utils";
 import {Modules} from "@medusajs/framework/utils"
 
@@ -35,21 +35,27 @@ export const POST = async (
             }
         });
 
-        const payment = await processPaymentWorkflow(req.scope)
-            .run({
-                input: {
-                    action: "authorized",
-                    data: {
-                        session_id: id,
-                        amount: amount,
-                    }
-                }
-            })
+        const payment = authorizePaymentSessionStep({
+            id,
+            context: {} // The context can be empty since data is retrieved from the payment-session object.
+        })
+
+        // const payment = await processPaymentWorkflow(req.scope)
+        //     .run({
+        //         input: {
+        //             action: "authorized",
+        //             data: {
+        //                 session_id: id,
+        //                 amount: amount,
+        //             }
+        //         }
+        //     })
 
         res.status(200).json({
             success: true,
             message: `Payment authorized`,
         })
+
     } catch (e) {
         logger.error(`Could not update the payment session: ${e.message}`);
         res.status(400).json({

--- a/src/api/store/mercury/authorize/route.ts
+++ b/src/api/store/mercury/authorize/route.ts
@@ -35,10 +35,10 @@ export const POST = async (
             }
         });
 
-        const payment = authorizePaymentSessionStep({
+        const payment = await paymentModuleService.authorizePaymentSession(
             id,
-            context: {} // The context can be empty since data is retrieved from the payment-session object.
-        })
+            {} // The context can be empty since data is retrieved from the payment-session object.
+        )
 
         // const payment = await processPaymentWorkflow(req.scope)
         //     .run({


### PR DESCRIPTION
- Modify provider method arguments to match abstract class.
- Fix updatePayment method to return non-empty data object.
- Use authorizePayment from paymentModuleService instead of processPaymentWorkflow since the latter is meant for webhook events. Also, since the payment-session is associated with a cart, it will complete the cart but the frontend completes the cart separately. 