### PR TITLE
fix: update the authorize function

### DIFF
--- a/src/api/store/mercury/authorize/route.ts
+++ b/src/api/store/mercury/authorize/route.ts
@@ -1,7 +1,7 @@
 import {MedusaRequest, MedusaResponse} from "@medusajs/framework/http";
-import {processPaymentWorkflow} from "@medusajs/medusa/core-flows"
+import {processPaymentWorkflow} from "@medusajs/medusa/core-flows";
 import {ContainerRegistrationKeys} from "@medusajs/framework/utils";
-import {Modules} from "@medusajs/framework/utils"
+import {Modules} from "@medusajs/framework/utils";
 
 export const POST = async (
     req: MedusaRequest,
@@ -9,52 +9,96 @@ export const POST = async (
 ) => {
     const query = req.scope.resolve(ContainerRegistrationKeys.QUERY);
     const logger = req.scope.resolve(ContainerRegistrationKeys.LOGGER);
-    const paymentModuleService = req.scope.resolve(Modules.PAYMENT)
+    const paymentModuleService = req.scope.resolve(Modules.PAYMENT);
 
-    const {id, currency_code, amount, tx_hash} = req.body as {
-        id: string
-        currency_code: string
-        amount: number
-        tx_hash: string
+    const {id, currency_code, amount, paymentStatus, txHash} = req.body as {
+        id: string;
+        currency_code: string;
+        amount: number;
+        paymentStatus?: string;
+        txHash?: string;
     };
 
-    if (!id || !tx_hash) {
+    if (!id) {
         res.status(400).json({
-            message: `Bad request`
-        })
+            success: false,
+            message: `Payment session ID is required`,
+        });
         return;
     }
 
     try {
-        const result = await paymentModuleService.updatePaymentSession({
-            id,
-            currency_code,
-            amount,
-            data: {
-                transaction_hash: tx_hash,
-            }
-        });
+        // First authorization (before transaction submission)
+        if (paymentStatus === "pending" && !txHash) {
+            logger.info(`Initial payment authorization for session: ${id}`);
 
-        const payment = await processPaymentWorkflow(req.scope)
-            .run({
+            // Update payment session with pending status
+            await paymentModuleService.updatePaymentSession({
+                id,
+                currency_code,
+                amount,
+                data: {
+                    payment_status: "pending",
+                    authorized_at: new Date().toISOString(),
+                },
+            });
+
+            res.status(200).json({
+                success: true,
+                message: `Payment pre-authorized successfully`,
+            });
+            return;
+        }
+
+        // Second authorization (after transaction submission with txHash)
+        if (txHash) {
+            logger.info(
+                `Final payment authorization for session: ${id} with txHash: ${txHash}`
+            );
+
+            // Update payment session with transaction hash
+            await paymentModuleService.updatePaymentSession({
+                id,
+                currency_code,
+                amount,
+                data: {
+                    transaction_hash: txHash,
+                    payment_status: "authorized",
+                    completed_at: new Date().toISOString(),
+                },
+            });
+
+            // Process the payment workflow
+            const payment = await processPaymentWorkflow(req.scope).run({
                 input: {
                     action: "authorized",
                     data: {
                         session_id: id,
                         amount: amount,
-                    }
-                }
-            })
+                    },
+                },
+            });
 
-        res.status(200).json({
-            success: true,
-            message: `Payment authorized`,
-        })
+            res.status(200).json({
+                success: true,
+                message: `Payment authorized successfully with transaction hash: ${txHash}`,
+            });
+            return;
+        }
+
+        // Fallback for backward compatibility
+        if (!txHash) {
+            res.status(400).json({
+                success: false,
+                message: `Transaction hash is required for final authorization`,
+            });
+            return;
+        }
     } catch (e) {
         logger.error(`Could not update the payment session: ${e.message}`);
         res.status(400).json({
             success: false,
-            message: e.message
-        })
+            message: e.message,
+        });
     }
-}
+};


### PR DESCRIPTION
Previously, when there was an error at the /authorize endpoint, the txHash was still generated and the submit function was executed, which caused the payment to be withdrawn from the wallet regardless of the authorization error. To prevent this, I now first check if the payment is authorized (i.e., paymentStatus: "pending"). Only after confirming this status do I proceed with the payment transaction.

<img width="1137" height="614" alt="image" src="https://github.com/user-attachments/assets/aa504040-4090-4cc2-85e5-858d9fc202b1" />


<img width="1155" height="632" alt="image" src="https://github.com/user-attachments/assets/e504ce7d-ac1e-4826-9dca-e1d85b3e6251" />
